### PR TITLE
Fixed the invalid Go module path of the plugin

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module steampipe-plugin-crowdstrike
+module github.com/turbot/steampipe-plugin-crowdstrike
 
 go 1.21
 

--- a/main.go
+++ b/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"steampipe-plugin-crowdstrike/crowdstrike"
+	"github.com/turbot/steampipe-plugin-crowdstrike/crowdstrike"
 
 	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
 )


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>
  
```
Add example SQL query results here (please include the input queries as well)
```
</details>
