### PR TITLE
Fix `strfmtDatetimeTransformer` and `epochTimestampTransformer` in `crowdstrike_alert` table

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,8 @@
 # Output Binary
 steampipe-plugin-hibp
 steampipe-plugin-hibp.plugin
+
+# macOS files
+.DS_Store
+.AppleDouble
+.LSOverride

--- a/crowdstrike/common_transform.go
+++ b/crowdstrike/common_transform.go
@@ -9,9 +9,45 @@ import (
 )
 
 func strfmtDatetimeTransformer(ctx context.Context, td *transform.TransformData) (interface{}, error) {
-	return td.Value.(*strfmt.DateTime).String(), nil
+	if td == nil || td.Value == nil {
+		return nil, nil
+	}
+
+	switch v := td.Value.(type) {
+	case *strfmt.DateTime:
+		if v == nil {
+			return nil, nil
+		}
+		return v.String(), nil
+	case strfmt.DateTime:
+		return v.String(), nil
+	default:
+		return nil, nil
+	}
 }
 func epochTimestampTransformer(ctx context.Context, td *transform.TransformData) (interface{}, error) {
-	v := td.Value.(*int64)
-	return time.Unix(*v, 0).Format(time.RFC3339), nil
+	if td == nil || td.Value == nil {
+		return nil, nil
+	}
+
+	switch v := td.Value.(type) {
+	case *int64:
+		if v == nil {
+			return nil, nil
+		}
+		return time.Unix(*v, 0).Format(time.RFC3339), nil
+	case int64:
+		return time.Unix(v, 0).Format(time.RFC3339), nil
+	case *int:
+		if v == nil {
+			return nil, nil
+		}
+		return time.Unix(int64(*v), 0).Format(time.RFC3339), nil
+	case int:
+		return time.Unix(int64(v), 0).Format(time.RFC3339), nil
+	case float64:
+		return time.Unix(int64(v), 0).Format(time.RFC3339), nil
+	default:
+		return nil, nil
+	}
 }


### PR DESCRIPTION
Pushing this in the scope of https://github.com/turbot/steampipe-plugin-crowdstrike/issues/49, to fix the `strfmtDatetimeTransformer` and `epochTimestampTransformer` functions in the `crowdstrike_alert` table, that was causing the error below (described [here](https://github.com/turbot/steampipe-plugin-crowdstrike/issues/49#issuecomment-3251088253) as well):

```sh
Error: crowdstrike: failed to populate column 'context_timestamp': rpc error: code = Internal desc = transform strfmtDatetimeTransformer failed with panic interface conversion: interface {} is strfmt.DateTime, not *strfmt.DateTime (SQLSTATE HV000)
``` 